### PR TITLE
[switchbot] made discovery case insensitive, added bot device initialization

### DIFF
--- a/bundles/org.openhab.binding.switchbot/src/main/java/org/openhab/binding/switchbot/internal/handler/SwitchbotAccountHandler.java
+++ b/bundles/org.openhab.binding.switchbot/src/main/java/org/openhab/binding/switchbot/internal/handler/SwitchbotAccountHandler.java
@@ -20,6 +20,7 @@ import java.util.Properties;
 import org.eclipse.jdt.annotation.NonNull;
 import org.openhab.binding.switchbot.internal.config.SwitchbotAccountConfig;
 import org.openhab.binding.switchbot.internal.discovery.AllDevicesModel;
+import org.openhab.binding.switchbot.internal.discovery.BotDevice;
 import org.openhab.binding.switchbot.internal.discovery.CurtainDevice;
 import org.openhab.binding.switchbot.internal.discovery.HubDevice;
 import org.openhab.binding.switchbot.internal.discovery.SwitchbotDevice;
@@ -85,13 +86,13 @@ public class SwitchbotAccountHandler extends BaseBridgeHandler {
     private List<SwitchbotDevice> toSwitchbotDevices(AllDevicesModel allDevices) {
         List<SwitchbotDevice> devices = new ArrayList<>();
         for (AllDevicesModel.Device device : allDevices.getBody().getDeviceList()) {
-            switch (device.getDeviceType()) {
+            switch (device.getDeviceType().toLowerCase()) {
 
                 // curtains can be grouped. Create individual curtain devices as well as an additional device for the
                 // group.
                 // TODO decide if we want the master / slave actually discovered since it looks like you can't control
                 // them individually if grouped
-                case "Curtain":
+                case "curtain":
                     if (device.isGroup()) {
                         if (device.isMaster()) {
                             devices.add(new CurtainDevice(device.getDeviceName() + " (master)", device.getDeviceId(),
@@ -107,15 +108,17 @@ public class SwitchbotAccountHandler extends BaseBridgeHandler {
                         devices.add(new CurtainDevice(device.getDeviceName(), device.getDeviceId(), false));
                     }
                     break;
-                case "Hub Plus":
-                case "Hub Mini":
+                case "hub plus":
+                case "hub mini":
                     devices.add(new HubDevice(device.getDeviceName(), device.getDeviceId()));
                     break;
-                case "Bot":
-                case "Plug":
-                case "Meter":
-                case "Humidifier":
-                case "Smart Fan":
+                case "bot":
+                    devices.add(new BotDevice(device.getDeviceName(), device.getDeviceId()));
+                    break;
+                case "plug":
+                case "meter":
+                case "humidifier":
+                case "smart fan":
                     logger.warn(
                             "Known but unsupported device type discovered, will not be added to inbox: {} with deviceId {}",
                             device.getDeviceType(), device.getDeviceId());


### PR DESCRIPTION
merge upstream change for made discovery case insensitive, addded bot device initialization
<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/bindings/#include-the-binding-in-the-build
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->
